### PR TITLE
Change openFileInput to Public

### DIFF
--- a/Source/library/src/main/java/im/delight/android/webview/AdvancedWebView.java
+++ b/Source/library/src/main/java/im/delight/android/webview/AdvancedWebView.java
@@ -1220,7 +1220,7 @@ public class AdvancedWebView extends WebView {
 	}
 
 	@SuppressLint("NewApi")
-	protected void openFileInput(final ValueCallback<Uri> fileUploadCallbackFirst, final ValueCallback<Uri[]> fileUploadCallbackSecond, final boolean allowMultiple) {
+	public void openFileInput(final ValueCallback<Uri> fileUploadCallbackFirst, final ValueCallback<Uri[]> fileUploadCallbackSecond, final boolean allowMultiple) {
 		if (mFileUploadCallbackFirst != null) {
 			mFileUploadCallbackFirst.onReceiveValue(null);
 		}


### PR DESCRIPTION
There are cases where we want to select upload options based on camera, gallery or the default handler of the webview (file manager).
Changing openFileInput to public we can postpone the execution of the method, based on user selection.